### PR TITLE
Use a list of objects for client keys config

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ Before using this module, you'll need to generate a key pair for your server and
   - `wg genkey | tee server-privatekey | wg pubkey > server-publickey`
 - Add the server private key to the AWS SSM parameter: `/wireguard/wg-server-private-key`
   - `aws ssm put-parameter --name /wireguard/wg-server-private-key --type SecureString --value $ServerPrivateKeyValue`
-- Add each client's public key, along with the next available IP address as a key:value pair to the wg_client_public_keys map. See Usage for details.
+- Add each client's public key, along with the next available IP address to the wg_client_public_keys list. See Usage for details.
 
 ## Variables
 | Variable Name | Type | Required |Description |
@@ -29,7 +29,7 @@ Before using this module, you'll need to generate a key pair for your server and
 |`asg_max_size`|`integer`|Optional - default to `1`|Number of VPN servers to permit maximum, only makes sense in loadbalanced scenario.|
 |`instance_type`|`string`|Optional - defaults to `t2.micro`|Instance Size of VPN server.|
 |`wg_server_net`|`cidr address and netmask`|Yes|The server ip allocation and net - wg_client_public_keys entries MUST be in this netmask range.|
-|`wg_client_public_keys`|`list`|Yes|List of maps of client IP/netmasks and public keys. See Usage for details. See Examples for formatting.|
+|`wg_client_public_keys`|`list`|Yes|List of client objects with IP and public key. See Usage for details. See Examples for formatting.|
 |`wg_server_port`|`integer`|Optional - defaults to `51820`|Port to run wireguard service on, wireguard standard is 51820.|
 |`wg_persistent_keepalive`|`integer`|Optional - defaults to `25`|Regularity of Keepalives, useful for NAT stability.|
 |`wg_server_private_key_param`|`string`|Optional - defaults to `/wireguard/wg-server-private-key`|The Parameter Store key to use for the VPN server Private Key.|

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ Before using this module, you'll need to generate a key pair for your server and
   - `wg genkey | tee server-privatekey | wg pubkey > server-publickey`
 - Add the server private key to the AWS SSM parameter: `/wireguard/wg-server-private-key`
   - `aws ssm put-parameter --name /wireguard/wg-server-private-key --type SecureString --value $ServerPrivateKeyValue`
-- Add each client's public key, along with the next available IP address to the wg_client_public_keys list. See Usage for details.
+- Add each client's public key, along with the next available IP address to the wg_clients list. See Usage for details.
 
 ## Variables
 | Variable Name | Type | Required |Description |
@@ -28,8 +28,8 @@ Before using this module, you'll need to generate a key pair for your server and
 |`asg_desired_capacity`|`integer`|Optional - default to `1`|Number of VPN servers to maintain, only makes sense in loadbalanced scenario.|
 |`asg_max_size`|`integer`|Optional - default to `1`|Number of VPN servers to permit maximum, only makes sense in loadbalanced scenario.|
 |`instance_type`|`string`|Optional - defaults to `t2.micro`|Instance Size of VPN server.|
-|`wg_server_net`|`cidr address and netmask`|Yes|The server ip allocation and net - wg_client_public_keys entries MUST be in this netmask range.|
-|`wg_client_public_keys`|`list`|Yes|List of client objects with IP and public key. See Usage for details. See Examples for formatting.|
+|`wg_server_net`|`cidr address and netmask`|Yes|The server ip allocation and net - wg_clients entries MUST be in this netmask range.|
+|`wg_clients`|`list`|Yes|List of client objects with IP and public key. See Usage for details. See Examples for formatting.|
 |`wg_server_port`|`integer`|Optional - defaults to `51820`|Port to run wireguard service on, wireguard standard is 51820.|
 |`wg_persistent_keepalive`|`integer`|Optional - defaults to `25`|Regularity of Keepalives, useful for NAT stability.|
 |`wg_server_private_key_param`|`string`|Optional - defaults to `/wireguard/wg-server-private-key`|The Parameter Store key to use for the VPN server Private Key.|

--- a/examples/complex_elb/main.tf
+++ b/examples/complex_elb/main.tf
@@ -10,9 +10,21 @@ module "wireguard" {
   asg_max_size                  = 5                # this cleanly permits us to allow rolling updates, growing and shrinking
   wg_server_net                 = "192.168.2.1/24" # client IPs MUST exist in this net
   wg_client_public_keys = [
-    { "192.168.2.2/32" = "QFX/DXxUv56mleCJbfYyhN/KnLCrgp7Fq2fyVOk/FWU=" }, # make sure these are correct
-    { "192.168.2.3/32" = "+IEmKgaapYosHeehKW8MCcU65Tf5e4aXIvXGdcUlI0Q=" }, # wireguard is sensitive
-    { "192.168.2.4/32" = "WO0tKrpUWlqbl/xWv6riJIXipiMfAEKi51qvHFUU30E=" }, # to bad configuration
+    {
+      name = "example1"
+      public_key = "QFX/DXxUv56mleCJbfYyhN/KnLCrgp7Fq2fyVOk/FWU="
+      client_ip = "192.168.2.2/32"
+    },
+    {
+      name = "example2"
+      public_key = "+IEmKgaapYosHeehKW8MCcU65Tf5e4aXIvXGdcUlI0Q="
+      client_ip = "192.168.2.3/32"
+    },
+    {
+      name = "example3"
+      public_key = "WO0tKrpUWlqbl/xWv6riJIXipiMfAEKi51qvHFUU30E="
+      client_ip = "192.168.2.4/32"
+    },
   ]
 }
 

--- a/examples/complex_elb/main.tf
+++ b/examples/complex_elb/main.tf
@@ -9,7 +9,7 @@ module "wireguard" {
   asg_desired_capacity          = 2                # we want two servers running most of the time
   asg_max_size                  = 5                # this cleanly permits us to allow rolling updates, growing and shrinking
   wg_server_net                 = "192.168.2.1/24" # client IPs MUST exist in this net
-  wg_client_public_keys = [
+  wg_clients = [
     {
       name = "example1"
       public_key = "QFX/DXxUv56mleCJbfYyhN/KnLCrgp7Fq2fyVOk/FWU="

--- a/examples/complex_elb/main.tf
+++ b/examples/complex_elb/main.tf
@@ -11,19 +11,19 @@ module "wireguard" {
   wg_server_net                 = "192.168.2.1/24" # client IPs MUST exist in this net
   wg_clients = [
     {
-      name = "example1"
+      name       = "example1"
       public_key = "QFX/DXxUv56mleCJbfYyhN/KnLCrgp7Fq2fyVOk/FWU="
-      client_ip = "192.168.2.2/32"
+      client_ip  = "192.168.2.2/32"
     },
     {
-      name = "example2"
+      name       = "example2"
       public_key = "+IEmKgaapYosHeehKW8MCcU65Tf5e4aXIvXGdcUlI0Q="
-      client_ip = "192.168.2.3/32"
+      client_ip  = "192.168.2.3/32"
     },
     {
-      name = "example3"
+      name       = "example3"
       public_key = "WO0tKrpUWlqbl/xWv6riJIXipiMfAEKi51qvHFUU30E="
-      client_ip = "192.168.2.4/32"
+      client_ip  = "192.168.2.4/32"
     },
   ]
 }

--- a/examples/simple_eip/main.tf
+++ b/examples/simple_eip/main.tf
@@ -14,19 +14,19 @@ module "wireguard" {
   wg_server_net = "192.168.2.1/24" # client IPs MUST exist in this net
   wg_clients = [
     {
-      name = "example1"
+      name       = "example1"
       public_key = "QFX/DXxUv56mleCJbfYyhN/KnLCrgp7Fq2fyVOk/FWU="
-      client_ip = "192.168.2.2/32"
+      client_ip  = "192.168.2.2/32"
     },
     {
-      name = "example2"
+      name       = "example2"
       public_key = "+IEmKgaapYosHeehKW8MCcU65Tf5e4aXIvXGdcUlI0Q="
-      client_ip = "192.168.2.3/32"
+      client_ip  = "192.168.2.3/32"
     },
     {
-      name = "example3"
+      name       = "example3"
       public_key = "WO0tKrpUWlqbl/xWv6riJIXipiMfAEKi51qvHFUU30E="
-      client_ip = "192.168.2.4/32"
+      client_ip  = "192.168.2.4/32"
     },
   ]
 }

--- a/examples/simple_eip/main.tf
+++ b/examples/simple_eip/main.tf
@@ -12,7 +12,7 @@ module "wireguard" {
   subnet_ids    = ["subnet-01234567"]
   eip_id        = "${aws_eip.wireguard.id}"
   wg_server_net = "192.168.2.1/24" # client IPs MUST exist in this net
-  wg_client_public_keys = [
+  wg_clients = [
     {
       name = "example1"
       public_key = "QFX/DXxUv56mleCJbfYyhN/KnLCrgp7Fq2fyVOk/FWU="

--- a/examples/simple_eip/main.tf
+++ b/examples/simple_eip/main.tf
@@ -13,8 +13,20 @@ module "wireguard" {
   eip_id        = "${aws_eip.wireguard.id}"
   wg_server_net = "192.168.2.1/24" # client IPs MUST exist in this net
   wg_client_public_keys = [
-    { "192.168.2.2/32" = "QFX/DXxUv56mleCJbfYyhN/KnLCrgp7Fq2fyVOk/FWU=" }, # make sure these are correct
-    { "192.168.2.3/32" = "+IEmKgaapYosHeehKW8MCcU65Tf5e4aXIvXGdcUlI0Q=" }, # wireguard is sensitive
-    { "192.168.2.4/32" = "WO0tKrpUWlqbl/xWv6riJIXipiMfAEKi51qvHFUU30E=" }, # to bad configuration
+    {
+      name = "example1"
+      public_key = "QFX/DXxUv56mleCJbfYyhN/KnLCrgp7Fq2fyVOk/FWU="
+      client_ip = "192.168.2.2/32"
+    },
+    {
+      name = "example2"
+      public_key = "+IEmKgaapYosHeehKW8MCcU65Tf5e4aXIvXGdcUlI0Q="
+      client_ip = "192.168.2.3/32"
+    },
+    {
+      name = "example3"
+      public_key = "WO0tKrpUWlqbl/xWv6riJIXipiMfAEKi51qvHFUU30E="
+      client_ip = "192.168.2.4/32"
+    },
   ]
 }

--- a/main.tf
+++ b/main.tf
@@ -13,12 +13,12 @@ data "template_file" "user_data" {
 
 data "template_file" "wg_client_data_json" {
   template = file("${path.module}/templates/client-data.tpl")
-  count    = length(var.wg_client_public_keys)
+  count    = length(var.wg_clients)
 
   vars = {
-    client_name          = var.wg_client_public_keys[count.index].name
-    client_pub_key       = var.wg_client_public_keys[count.index].public_key
-    client_ip            = var.wg_client_public_keys[count.index].client_ip
+    client_name          = var.wg_clients[count.index].name
+    client_pub_key       = var.wg_clients[count.index].public_key
+    client_ip            = var.wg_clients[count.index].client_ip
     persistent_keepalive = var.wg_persistent_keepalive
   }
 }

--- a/main.tf
+++ b/main.tf
@@ -16,8 +16,9 @@ data "template_file" "wg_client_data_json" {
   count    = length(var.wg_client_public_keys)
 
   vars = {
-    client_pub_key       = element(values(var.wg_client_public_keys[count.index]), 0)
-    client_ip            = element(keys(var.wg_client_public_keys[count.index]), 0)
+    client_name          = var.wg_client_public_keys[count.index].name
+    client_pub_key       = var.wg_client_public_keys[count.index].public_key
+    client_ip            = var.wg_client_public_keys[count.index].client_ip
     persistent_keepalive = var.wg_persistent_keepalive
   }
 }

--- a/variables.tf
+++ b/variables.tf
@@ -32,8 +32,8 @@ variable "subnet_ids" {
 }
 
 variable "wg_client_public_keys" {
-  # type        = map(string)
-  description = "List of maps of client IPs and public keys. See Usage in README for details."
+  type        = list(object({ name=string, public_key=string, client_ip=string }))
+  description = "List of client objects with IP and public key. See Usage in README for details."
 }
 
 variable "wg_server_net" {

--- a/variables.tf
+++ b/variables.tf
@@ -31,7 +31,7 @@ variable "subnet_ids" {
   description = "A list of subnets for the Autoscaling Group to use for launching instances. May be a single subnet, but it must be an element in a list."
 }
 
-variable "wg_client_public_keys" {
+variable "wg_clients" {
   type        = list(object({ name=string, public_key=string, client_ip=string }))
   description = "List of client objects with IP and public key. See Usage in README for details."
 }


### PR DESCRIPTION
The map format for `wg_client_public_keys`, which has the client IPs as keys, causes linting errors in Jetbrains IDE's when quoted, and terraform errors when unquoted.

![image](https://user-images.githubusercontent.com/904004/99116533-0bfce500-2659-11eb-8a4b-88d340273c55.png)
![image](https://user-images.githubusercontent.com/904004/99116608-28008680-2659-11eb-85aa-44a0e6c73764.png)

This PR changes the variable to use a list of objects instead.