### PR TITLE
Add `use_eip` variable to control Elastic IP use, instead of checking `eip_id = "disabled"`

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,8 @@ Before using this module, you'll need to generate a key pair for your server and
 |`ssh_key_id`|`string`|Yes|A SSH public key ID to add to the VPN instance.|
 |`vpc_id`|`string`|Yes|The VPC ID in which Terraform will launch the resources.|
 |`env`|`string`|Optional - defaults to `prod`|The name of environment for WireGuard. Used to differentiate multiple deployments.|
-|`eip_id`|`string`|Optional|The [Elastic IP](https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/elastic-ip-addresses-eip.html) ID to which the VPN server will attach. Useful for avoiding changing IPs.|
+|`use_eip`|`bool`|Optional|Whether to attach an [Elastic IP](https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/elastic-ip-addresses-eip.html) address to the VPN server. Useful for avoiding changing IPs.|
+|`eip_id`|`string`|Optional|When `use_eip` is enabled, specify the ID of the Elastic IP to which the VPN server will attach.|
 |`target_group_arns`|`string`|Optional|The Loadbalancer Target Group to which the vpn server ASG will attach.|
 |`additional_security_group_ids`|`list`|Optional|Used to allow added access to reach the WG servers or allow loadbalancer health checks.|
 |`asg_min_size`|`integer`|Optional - default to `1`|Number of VPN servers to permit minimum, only makes sense in loadbalanced scenario.|

--- a/examples/simple_eip/main.tf
+++ b/examples/simple_eip/main.tf
@@ -10,6 +10,7 @@ module "wireguard" {
   ssh_key_id    = "ssh-key-id-0987654"
   vpc_id        = "vpc-01234567"
   subnet_ids    = ["subnet-01234567"]
+  use_eip       = true
   eip_id        = "${aws_eip.wireguard.id}"
   wg_server_net = "192.168.2.1/24" # client IPs MUST exist in this net
   wg_client_public_keys = [

--- a/main.tf
+++ b/main.tf
@@ -6,6 +6,7 @@ data "template_file" "user_data" {
     wg_server_net         = var.wg_server_net
     wg_server_port        = var.wg_server_port
     peers                 = join("\n", data.template_file.wg_client_data_json.*.rendered)
+    use_eip               = var.use_eip ? "enabled" : "disabled"
     eip_id                = var.eip_id
     wg_server_interface   = var.wg_server_interface
   }
@@ -51,10 +52,10 @@ resource "aws_launch_configuration" "wireguard_launch_config" {
   image_id                    = var.ami_id == null ? data.aws_ami.ubuntu.id : var.ami_id
   instance_type               = var.instance_type
   key_name                    = var.ssh_key_id
-  iam_instance_profile        = (var.eip_id != "disabled" ? aws_iam_instance_profile.wireguard_profile[0].name : null)
+  iam_instance_profile        = (var.use_eip ? aws_iam_instance_profile.wireguard_profile[0].name : null)
   user_data                   = data.template_file.user_data.rendered
   security_groups             = local.security_groups_ids
-  associate_public_ip_address = (var.eip_id != "disabled" ? true : false)
+  associate_public_ip_address = var.use_eip
 
   lifecycle {
     create_before_destroy = true

--- a/templates/user-data.txt
+++ b/templates/user-data.txt
@@ -15,7 +15,7 @@ ${peers}
 EOF
 
 # we go with the eip if it is provided
-if [ "${eip_id}" != "disabled" ]; then
+if [ "${use_eip}" != "disabled" ]; then
   export INSTANCE_ID=$(curl -s http://169.254.169.254/latest/meta-data/instance-id)
   export REGION=$(curl -fsq http://169.254.169.254/latest/meta-data/placement/availability-zone | sed 's/[a-z]$//')
   aws --region $${REGION} ec2 associate-address --allocation-id ${eip_id} --instance-id $${INSTANCE_ID}

--- a/variables.tf
+++ b/variables.tf
@@ -51,9 +51,15 @@ variable "wg_persistent_keepalive" {
   description = "Persistent Keepalive - useful for helping connection stability over NATs."
 }
 
+variable "use_eip" {
+  type        = bool
+  default     = false
+  description = "Whether to enable Elastic IP switching code in user-data on wg server startup. If true, eip_id must also be set to the ID of the Elastic IP."
+}
+
 variable "eip_id" {
-  default     = "disabled"
-  description = "If we detect the default 'disabled' we avoid the EIP switching code in user-data on wg server startup, if an EIP ID is provided the instance will attempt to switch EIP."
+  type        = string
+  description = "ID of the Elastic IP to use, when use_eip is enabled."
 }
 
 variable "additional_security_group_ids" {

--- a/wireguard-iam.tf
+++ b/wireguard-iam.tf
@@ -25,7 +25,7 @@ resource "aws_iam_policy" "wireguard_policy" {
   name        = "tf-wireguard-${var.env}"
   description = "Terraform Managed. Allows Wireguard instance to attach EIP."
   policy      = data.aws_iam_policy_document.wireguard_policy_doc.json
-  count       = (var.eip_id != "disabled" ? 1 : 0) # only used for EIP mode
+  count       = (var.use_eip ? 1 : 0) # only used for EIP mode
 }
 
 resource "aws_iam_role" "wireguard_role" {
@@ -33,17 +33,17 @@ resource "aws_iam_role" "wireguard_role" {
   description        = "Terraform Managed. Role to allow Wireguard instance to attach EIP."
   path               = "/"
   assume_role_policy = data.aws_iam_policy_document.ec2_assume_role.json
-  count              = (var.eip_id != "disabled" ? 1 : 0) # only used for EIP mode
+  count              = (var.use_eip ? 1 : 0) # only used for EIP mode
 }
 
 resource "aws_iam_role_policy_attachment" "wireguard_roleattach" {
   role       = aws_iam_role.wireguard_role[0].name
   policy_arn = aws_iam_policy.wireguard_policy[0].arn
-  count      = (var.eip_id != "disabled" ? 1 : 0) # only used for EIP mode
+  count      = (var.use_eip ? 1 : 0) # only used for EIP mode
 }
 
 resource "aws_iam_instance_profile" "wireguard_profile" {
   name  = "tf-wireguard-${var.env}"
   role  = aws_iam_role.wireguard_role[0].name
-  count = (var.eip_id != "disabled" ? 1 : 0) # only used for EIP mode
+  count = (var.use_eip ? 1 : 0) # only used for EIP mode
 }


### PR DESCRIPTION
Fixes https://github.com/jmhale/terraform-aws-wireguard/issues/8

Splits out the configuration of whether to use an EIP and the EIP ID itself into separate variables (`use_eip`, `eip_id`). This ensures the plan always knows whether an EIP should be used even if the EIP ID is being set to an attribute of another resource that is being created in the plan (and whose value is therefore unknown).

Note this would be a breaking change to the module config.