### PR TITLE
Reduce MTU on server to 1500

### DIFF
--- a/templates/user-data.txt
+++ b/templates/user-data.txt
@@ -21,6 +21,9 @@ if [ "${use_eip}" != "disabled" ]; then
   aws --region $${REGION} ec2 associate-address --allocation-id ${eip_id} --instance-id $${INSTANCE_ID}
 fi
 
+# reduce MTU to prevent packet fragmentation with NAT
+ip link set dev ${wg_server_interface} mtu 1500
+
 chown -R root:root /etc/wireguard/
 chmod -R og-rwx /etc/wireguard/*
 sed -i 's/#net.ipv4.ip_forward=1/net.ipv4.ip_forward=1/' /etc/sysctl.conf


### PR DESCRIPTION
Connectivity from `client -> private VPC` behind wireguard server (as NAT) doesn't work with default MTU of 9001 on EC2 instances.

https://www.reddit.com/r/WireGuard/comments/fefufu/another_wireguard_on_ec2_issue/