### PR TITLE
Use tag instead of tags on aws_autoscaling_group

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -91,26 +91,9 @@ resource "aws_autoscaling_group" "wireguard_asg" {
     create_before_destroy = true
   }
 
-  tags = [
-    {
-      key                 = "Name"
-      value               = aws_launch_configuration.wireguard_launch_config.name
-      propagate_at_launch = true
-    },
-    {
-      key                 = "Project"
-      value               = "wireguard"
-      propagate_at_launch = true
-    },
-    {
-      key                 = "env"
-      value               = var.env
-      propagate_at_launch = true
-    },
-    {
-      key                 = "tf-managed"
-      value               = "True"
-      propagate_at_launch = true
-    },
-  ]
+  tag {
+    key = "Name"
+    value = aws_launch_configuration.wireguard_launch_config.name
+    propagate_at_launch = true
+  }
 }

--- a/main.tf
+++ b/main.tf
@@ -96,4 +96,10 @@ resource "aws_autoscaling_group" "wireguard_asg" {
     value = aws_launch_configuration.wireguard_launch_config.name
     propagate_at_launch = true
   }
+
+  tag {
+    key = "env"
+    value = var.env
+    propagate_at_launch = true
+  }
 }


### PR DESCRIPTION
`tags` attribute is deprecated.